### PR TITLE
Adds support for append html attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # The directory Mix will write compiled artifacts to.
 /_build
+/.elixir_ls/
 
 # If you run "mix test --cover", coverage assets end up here.
 /cover

--- a/lib/phoenix_inline_svg/helpers.ex
+++ b/lib/phoenix_inline_svg/helpers.ex
@@ -164,7 +164,25 @@ defmodule PhoenixInlineSvg.Helpers do
       apply_opt(acc, opt, value)
     end)
   end
+
+  defp apply_opt(html, :class, value), do: append_html_attribute(html, "class", value)
+  defp apply_opt(html, :id, value), do: append_html_attribute(html, "id", value)
   defp apply_opt(_, opt, _), do: raise "Invalid option #{opt}!"
+
+  defp append_html_attribute(html, attribute, value) do
+    html =
+      case String.contains?(html, "#{attribute}=") do
+        false -> append_empty_opt(html, attribute)
+        true -> html
+      end
+
+    Regex.replace(~r/#{attribute}=*"/, html, "#{attribute}=\"#{value} \\g{1}")
+  end
+
+  defp append_empty_opt(html, opt) do
+    String.replace(html, "<svg", "<svg #{opt}=\"\"")
+  end
+
   defp safety_string(html) do
     {:safe, html}
   end

--- a/lib/phoenix_inline_svg/helpers.ex
+++ b/lib/phoenix_inline_svg/helpers.ex
@@ -8,23 +8,22 @@ defmodule PhoenixInlineSvg.Helpers do
   The preferred way of using this library is to add the helpers to the quoted
   `view` in your `web.ex` file.
 
-  ```elixir
-  def view do
-    quote do
-      use PhoenixInlineSvg.Helpers, otp_app: :phoenix_inline_svg
-    end
-  end
-  ```
+      def view do
+        quote do
+          use PhoenixInlineSvg.Helpers, otp_app: :phoenix_inline_svg
+        end
+      end
 
   Using the new way you can get svg images using the methods:
 
-    ```elixir
-    # Get an image with the default collection
-    svg_image("image_name")
+      # Get an image with the default collection
+      svg_image("image_name")
 
-    # Get an image with a different collection
-    svg_image("image_name", "collection_name")
-    ```
+      # Get an image with a different collection
+      svg_image("image_name", "collection_name")
+
+      # Get an image and append html attributes to svg tag
+      svg_image("image_name", class: "elixir-is-awesome", id: "inline-svg")
 
   ## Old Way
 
@@ -32,13 +31,12 @@ defmodule PhoenixInlineSvg.Helpers do
   `web/web.ex` which will always pull the SVG files from the disk (unless you
   are using a caching class).
 
-    ```
-    def view do
-      quote do
-        import PhoenixInlineSvg.Helpers
+
+      def view do
+        quote do
+          import PhoenixInlineSvg.Helpers
+        end
       end
-    end
-    ```
 
   *Note:* If you are setting a custom directory for the SVG files and are using
   Exrm or Distillery, you will need to ensure that the directory you set is in
@@ -47,15 +45,12 @@ defmodule PhoenixInlineSvg.Helpers do
   ## In Both Configurations
 
   By default SVG files are loaded from:
-  ```
   priv/static/svg/
-  ```
 
   The directory where SVG files are loaded from can be configured
   by setting the configuration variable:
-  ```
-  config :phoenix_inline_svg, dir: "some/other/dir"
-  ```
+
+      config :phoenix_inline_svg, dir: "some/other/dir"
 
   Where `some/other/dir` is a directory located in the Phoenix
   application directory.
@@ -76,21 +71,19 @@ defmodule PhoenixInlineSvg.Helpers do
 
   ## Examples
 
-    In the quoted `view` def of the `web/web/ex` you should add:
+  In the quoted `view` def of the `web/web/ex` you should add:
 
-    ```elixir
-    use PhoenixInlineSvg.Helpers, otp_app: :my_app_name
-    ```
+      use PhoenixInlineSvg.Helpers, otp_app: :my_app_name
 
-    This will create pre-built functions:
+  This will create pre-built functions:
 
-    ```elixir
-    # Default collection
-    svg_image("image_name")
+      # Default collection
 
-    # Named collection
-    svg_image("image_name", "collection_name")
-    ```
+      svg_image("image_name")
+
+      # Named collection
+      svg_image("image_name", "collection_name")
+
   """
   defmacro __using__([otp_app: app_name]) do
     svgs_path = Application.app_dir(app_name,
@@ -106,51 +99,84 @@ defmodule PhoenixInlineSvg.Helpers do
   end
 
   @doc """
-  Sends the contents of the SVG file `name` in the directory.
+  Sends the contents of the SVG file `name` in the configured
+  directory.
 
   Returns a safe HTML string with the contents of the SVG file
-  wrapped in an `i` HTML element with classes.
+  using the `default_collection` configuration.
+  "generic" value.
 
   ## Examples
-    ```
-    <%= svg_image(@conn, "home") %>
-    ```
+      <%= svg_image(@conn, "home") %>
 
-    Will result in output of:
-    ```
-    <i class="generic-svgs generic-home-svg">
-      <svg>...</svg>
-    </i>
-    ```
+  Will result in the output:
+  ```html
+  <svg>...</svg>
+  ```
+
+  The main function is `svg_image/4`.
 
   """
+
   def svg_image(conn, name) do
     svg_image(conn, name, config_or_default(:default_collection, "generic"))
   end
 
   @doc """
-  Sends the contents of the SVG file `name` in the directory.
+  Sends the contents of the SVG file `name` in the directory
+  with extra `opts` options.
 
   Returns a safe HTML string with the contents of the SVG file
-  wrapped in an `i` HTML element with classes.
+  after apply options.
+
+  Available options: `:id, :class`
 
   ## Examples
+      <%= svg_image(@conn, "home", class: "logo", id: "bounce-animation") %>
 
-    ```
-    <%= svg_image(@conn, "user", "fontawesome") %>
-    ```
+  Will result in the output:
 
-    Will result in the output:
-    ```
-    <i class="fontawesome-svgs fontawesome-home-svg">
-      <svg>...</svg>
-    </i>
-    ```
+  ```html
+  <svg class="logo" id="bounce-animation">...</svg>
+  ```
+
+  The main function is `svg_image/4`.
 
   """
   def svg_image(conn, name, opts) when is_list(opts) do
     svg_image(conn, name, config_or_default(:default_collection, "generic"), opts)
   end
+
+  @doc """
+  Sends the contents of the SVG file `name` in the `context`
+  directory with extra `opts` options.
+
+  Returns a safe HTML string with the contents of the SVG file
+  using the `default_collection` configuration.
+  `generic` value after apply options.
+
+  ## Examples
+  Find SVG file inside of "fontawesome" folder
+
+      <%= svg_image(@conn, "user", "fontawesome") %>
+
+  Will result in the output:
+  ```html
+  <svg>...</svg>
+  ```
+
+  Find SVG file inside of "icons" folder and add
+  class "fa fa-share" and id "bounce-animation"
+
+      <%= svg_image(@conn, "user", "icons", class: "fa fa-share", id: "bounce-animation") %>
+
+  Will result in the output:
+  ```html
+  <svg class="fa fa-share" id="bounce-animation">...</svg>
+  ```
+
+  """
+
   def svg_image(conn, name, collection, opts \\ []) do
     "#{collection}/#{name}.svg"
     |> read_svg_file(conn)

--- a/lib/phoenix_inline_svg/helpers.ex
+++ b/lib/phoenix_inline_svg/helpers.ex
@@ -148,12 +148,23 @@ defmodule PhoenixInlineSvg.Helpers do
     ```
 
   """
-  def svg_image(conn, name, collection) do
+  def svg_image(conn, name, opts) when is_list(opts) do
+    svg_image(conn, name, config_or_default(:default_collection, "generic"), opts)
+  end
+  def svg_image(conn, name, collection, opts \\ []) do
     "#{collection}/#{name}.svg"
     |> read_svg_file(conn)
+    |> apply_opts(opts)
     |> safety_string
   end
 
+  defp apply_opts(html, []), do: html
+  defp apply_opts(html, opts) do
+    Enum.reduce(opts, html, fn({opt, value}, acc) ->
+      apply_opt(acc, opt, value)
+    end)
+  end
+  defp apply_opt(_, opt, _), do: raise "Invalid option #{opt}!"
   defp safety_string(html) do
     {:safe, html}
   end


### PR DESCRIPTION
Inspired by [ruby inline_svg](https://github.com/jamesmartin/inline_svg) my intention is to make possible add html attributes in the svg found and allow it to be possible to make other modifications to the svg 


* Changes docs to [ExDoc](https://hexdocs.pm/elixir/writing-documentation.html) styles
  * Fixes html svg syntax hightlighting
* Adds support for options in svg_image function
* Makes `id` and `class` available options

Todo:
* Tests

WIP
