### PR TITLE
Remove quoted keyword list key

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule PhoenixInlineSvg.Mixfile do
 
   def cli_env() do
     [
-      "coveralls": :test,
+      coveralls: :test,
       "coveralls.detail": :test,
       "coveralls.post": :test,
       "coveralls.html": :test


### PR DESCRIPTION
This change stops a compiler warning form appearing on every compilation

```
warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted. Similar to atoms, keywords made exclusively of Unicode letters, numbers, underscore, and @ do not require quotes
  /app/deps/phoenix_inline_svg/mix.exs:19
```