### PR TITLE
Finish precompiled functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ Add `phoenix_inline_svg` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:phoenix_inline_svg, "~> 1.1"}]
+  [{:phoenix_inline_svg, "~> 1.2"}]
 end
 ```
 
-To make using this package easier add the helpers for this
-package as an import to your `web.ex` under the view quote:
+## Usage
 
 ```elixir
 def view do
@@ -33,18 +32,14 @@ def view do
 end
 ```
 
-## Usage
-
 ### Generic Collection
 
-If you have set up the import in the `web.ex` file a view can use
-this module by adding:
-
 ```elixir
-<%= PhoenixInlineSvg.Helpers.svg_image(@conn, "home") %>
+<%= svg_image("home") %>
 ```
 
 Where `home` is the name of the SVG file you want to load.
+
 This will output the HTML:
 
 ```html
@@ -59,11 +54,10 @@ By default this will load the SVG file from:
 
 ### Collections
 
-There is an optional argument in the function to allow for breaking up
-SVG files into collections (or folders on the filesystem):
+There is an optional argument in the function to allow for breaking up SVG files into collections (or folders on the filesystem):
 
 ```
-<%= svg_image(@conn, "user", "fontawesome") %>
+<%= svg_image("user", "fontawesome") %>
 ```
 
 Will result in the output:
@@ -81,10 +75,10 @@ This will load the SVG file from:
 ### HTML attributes
 
 You can also pass optional HTML attributes into the function to set
-those properties on the SVG when it is being created.
+those properties on the SVG.
 
 ```
-<%= svg_image(@conn, "home", class: "logo", id: "bounce-animation") %>
+<%= svg_image("home", class: "logo", id: "bounce-animation") %>
 ```
 
 Will result in the output:
@@ -96,26 +90,21 @@ Will result in the output:
 
 ## Configuration Options
 
-There are several _optional_ configuration settings for adjusting
-this package to your needs:
+There are several _optional_ configuration settings for adjusting this package to your needs:
 
 ### Directory
 
-The directory in the project to load image assets from. If you are using Exrm
-make sure you use a directory that is outputted to the projects `lib` directory
-after the release has been created.
+The directory in the project to load image assets from. If you are using Exrm make sure you use a directory that is outputted to the projects `lib` directory after the release has been created.
 
 ```elixir
 config :phoenix_inline_svg, dir: "/priv/somewhere/"
 ```
 
-The default value is `/priv/static/svg/` and is a directory relative to the
-project's root directory.
+The default value is `/priv/static/svg/` and is a directory relative to the project's root directory.
 
 ### Default Collection
 
-The name of the collection to use by default. This is usually overridden to be
-the primary collection of images.
+The name of the collection to use by default. This is usually overridden to be the primary collection of images.
 
 ```elixir
 config :phoenix_inline_svg, default_collection: "fontawesome"
@@ -140,19 +129,28 @@ The default value is:
 </svg>
 ```
 
-## Caching SVGs
+## Old Style
 
-**For Use with Import Only**: Do not use the caching class if you are using the
-`use PhoenixInlineSvg.Helpers, otp_app: :my_app_name` method due to static methods.
+To use this package in the old style, add the following line to the view function in your `my_app_web.ex` file.
 
-To improve the response time of the applicaiton it is recommended to cache the SVG files
-that are loaded from the disk to improve the performance by not fetching from the disk on
-every web request that has SVG assets.
+```elixir
+def view do
+  quote do
+    ...
+    import PhoenixInlineSvg.Helpers
+    ...
+  end
+end
+```
 
-The best way to set up caching is to create a new file in your applicaiton with the path:
-`lib/__MY_APP_NAME__/inline_svg_cache.ex`
+### Caching SVGs
 
-And the contents:
+Since the old style will read the images from disk on every request, you can enable caching through a GenServer.
+
+**For Use with Import Only**: If you use the new style, `use PhoenixInlineSvg.Helpers, otp_app: :my_app_name`, your images are already cached since they are loaded into functions at compile time.
+
+
+Add the following code to the file `lib/__MY_APP_NAME__/inline_svg_cache.ex`.
 
 **Note**: Be sure to change **\_\_MY_APP_NAME\_\_** to the name of your app.
 

--- a/lib/phoenix_inline_svg/helpers.ex
+++ b/lib/phoenix_inline_svg/helpers.ex
@@ -228,19 +228,19 @@ defmodule PhoenixInlineSvg.Helpers do
       |> List.first
     svg = read_svg_from_path(name)
 
-    quote do
+    generic_funcs = quote do
       def svg_image(unquote(filename)) do
-        unquote(PhoenixInlineSvg.Utils.safety_string(svg))
-      end
-
-      def svg_image(unquote(filename), unquote(collection)) do
-        unquote(PhoenixInlineSvg.Utils.safety_string(svg))
+        svg_image(unquote(filename), unquote(collection), [])
       end
 
       def svg_image(unquote(filename), opts) when is_list(opts) do
-        unquote(svg)
-        |> PhoenixInlineSvg.Utils.insert_attrs(opts)
-        |> PhoenixInlineSvg.Utils.safety_string
+        svg_image(unquote(filename), unquote(collection), opts)
+      end
+    end
+
+    explicit_funcs = quote do
+      def svg_image(unquote(filename), unquote(collection)) do
+        svg_image(unquote(filename), unquote(collection), [])
       end
 
       def svg_image(unquote(filename), unquote(collection), opts) do
@@ -249,5 +249,8 @@ defmodule PhoenixInlineSvg.Helpers do
         |> PhoenixInlineSvg.Utils.safety_string
       end
     end
+
+    [PhoenixInlineSvg.Utils.insert_generic_funcs(generic_funcs, collection), explicit_funcs]
+
   end
 end

--- a/lib/phoenix_inline_svg/helpers.ex
+++ b/lib/phoenix_inline_svg/helpers.ex
@@ -71,7 +71,7 @@ defmodule PhoenixInlineSvg.Helpers do
   """
   defmacro __using__([otp_app: app_name] = _opts) do
     svgs_path = Application.app_dir(app_name,
-      config_or_default(:dir, "priv/static/svg/"))
+      PhoenixInlineSvg.Utils.config_or_default(:dir, "priv/static/svg/"))
 
     svgs_path
     |> find_collection_sets
@@ -100,7 +100,7 @@ defmodule PhoenixInlineSvg.Helpers do
   """
 
   def svg_image(conn_or_endpoint, name) do
-    svg_image(conn_or_endpoint, name, config_or_default(:default_collection, "generic"))
+    svg_image(conn_or_endpoint, name, PhoenixInlineSvg.Utils.config_or_default(:default_collection, "generic"))
   end
 
   @doc """
@@ -121,7 +121,7 @@ defmodule PhoenixInlineSvg.Helpers do
 
   """
   def svg_image(conn_or_endpoint, name, attrs) when is_list(attrs) do
-    svg_image(conn_or_endpoint, name, config_or_default(:default_collection, "generic"), attrs)
+    svg_image(conn_or_endpoint, name, PhoenixInlineSvg.Utils.config_or_default(:default_collection, "generic"), attrs)
   end
 
   @doc """
@@ -161,7 +161,7 @@ defmodule PhoenixInlineSvg.Helpers do
       {:ok, result} ->
         String.trim(result)
       {:error, _} ->
-        config_or_default(:not_found,
+        PhoenixInlineSvg.Utils.config_or_default(:not_found,
           "<svg viewbox='0 0 60 60'>" <>
           "<text x='0' y='40' font-size='30' font-weight='bold'" <>
           "font-family='monospace'>Err</text></svg>")
@@ -171,7 +171,7 @@ defmodule PhoenixInlineSvg.Helpers do
   defp read_svg_file(icon_path, %Plug.Conn{} = conn) do
     [
       Application.app_dir(Phoenix.Controller.endpoint_module(conn).config(:otp_app)),
-      config_or_default(:dir, "priv/static/svg/"),
+      PhoenixInlineSvg.Utils.config_or_default(:dir, "priv/static/svg/"),
       icon_path
     ]
     |> Path.join
@@ -181,21 +181,13 @@ defmodule PhoenixInlineSvg.Helpers do
   defp read_svg_file(icon_path, endpoint) do
     [
       Application.app_dir(endpoint.config(:otp_app)),
-      config_or_default(:dir, "priv/static/svg/"),
+      PhoenixInlineSvg.Utils.config_or_default(:dir, "priv/static/svg/"),
       icon_path
     ]
     |> Path.join
     |> read_svg_from_path
   end
 
-  defp config_or_default(config, default) do
-    case Application.fetch_env(:phoenix_inline_svg, config) do
-      :error ->
-        default
-      {:ok, data} ->
-        data
-    end
-  end
 
   defp find_collection_sets(svgs_path) do
     case File.ls(svgs_path) do
@@ -259,6 +251,5 @@ defmodule PhoenixInlineSvg.Helpers do
     end
 
     [PhoenixInlineSvg.Utils.insert_generic_funcs(generic_funcs, collection), explicit_funcs]
-
   end
 end

--- a/lib/phoenix_inline_svg/helpers.ex
+++ b/lib/phoenix_inline_svg/helpers.ex
@@ -1,35 +1,35 @@
 defmodule PhoenixInlineSvg.Helpers do
   @moduledoc """
-  The module that adds the view helpers to fetch
-  and render SVG files into safe HTML.
+  This module adds view helpers for rendering SVG files into safe HTML.
 
-  ## New Way
-
-  The preferred way of using this library is to add the helpers to the quoted
-  `view` in your `web.ex` file.
+  To add the helpers, add the following to the quoted `view` in your `my_app_web.ex` file.
 
       def view do
         quote do
-          use PhoenixInlineSvg.Helpers, otp_app: :phoenix_inline_svg
+          use PhoenixInlineSvg.Helpers, otp_app: :my_app
         end
       end
 
-  Using the new way you can get svg images using the methods:
+  This will generate functions for each of your images, effectively caching them at compile time.
+  
+  You can call these functions like so
 
       # Get an image with the default collection
       svg_image("image_name")
 
-      # Get an image with a different collection
+      # Get an image and insert HTML attributes to svg tag
+      svg_image("image_name", class: "elixir-is-awesome", id: "inline-svg")
+
+      # Get an image from a different collection
       svg_image("image_name", "collection_name")
 
-      # Get an image and append html attributes to svg tag
-      svg_image("image_name", class: "elixir-is-awesome", id: "inline-svg")
+      # Get an image from a different collection and insert HTML attributes to the svg tag
+      svg_image("image_name", "collection_name", class: "elixir-is-awesome", id: "inline-svg")
+
 
   ## Old Way
 
-  As an alternative this module can be imported in the quoted `view` def of the
-  `web/web.ex` which will always pull the SVG files from the disk (unless you
-  are using a caching class).
+  As an alternative this module can be imported in the quoted `view` def of the `my_app_web.ex` which will always pull the SVG files from the disk (unless you are using a caching module).
 
 
       def view do
@@ -38,60 +38,44 @@ defmodule PhoenixInlineSvg.Helpers do
         end
       end
 
-  *Note:* If you are setting a custom directory for the SVG files and are using
-  Exrm or Distillery, you will need to ensure that the directory you set is in
-  the outputted `lib` directory of your application.
+  *Note:* If you are setting a custom directory for the SVG files and are using Exrm or Distillery, you will need to ensure that the directory you set is in the outputted `lib` directory of your application.
 
-  ## In Both Configurations
+  ## Configuration
 
-  By default SVG files are loaded from:
-  priv/static/svg/
+  By default SVG files are loaded from: priv/static/svg/
 
-  The directory where SVG files are loaded from can be configured
-  by setting the configuration variable:
+  The directory where SVG files are loaded from can be configured by setting the configuration variable:
 
       config :phoenix_inline_svg, dir: "some/other/dir"
 
-  Where `some/other/dir` is a directory located in the Phoenix
-  application directory.
+  Where `some/other/dir` is a directory located in the Phoenix application directory.
   """
 
   @doc """
-  The using method for the Inline SVG library precompiles the SVG images into
-  static function definitions.
+  The using macro precompiles the SVG images into functions.
 
-  **Note** These will not be able to be changed as the contents of the SVG files
-  will be directly loaded into the build of the application.
-
-  If you want to support changing SVGs on the fly without a new deployment, use
-  the `import` method instead.
-
-  Using this method requires you to tell the use statement what the name of your
-  OTP app is.
+  Using this macro requires passing your otp_app name as an argument.
 
   ## Examples
-
-  In the quoted `view` def of the `web/web/ex` you should add:
-
-      use PhoenixInlineSvg.Helpers, otp_app: :my_app_name
-
-  This will create pre-built functions:
 
       # Default collection
 
       svg_image("image_name")
+      svg_image("image_name", attrs)
 
       # Named collection
+      
       svg_image("image_name", "collection_name")
+      svg_image("image_name", "collection_name", attrs)
 
   """
-  defmacro __using__([otp_app: app_name]) do
+  defmacro __using__([otp_app: app_name] = _opts) do
     svgs_path = Application.app_dir(app_name,
       config_or_default(:dir, "priv/static/svg/"))
 
     svgs_path
     |> find_collection_sets
-    |> Enum.map(&create_cached_svg_image(&1, svgs_path))
+    |> Enum.map(&create_cached_svg_image(&1))
   end
 
   defmacro __using__(_) do
@@ -99,14 +83,10 @@ defmodule PhoenixInlineSvg.Helpers do
   end
 
   @doc """
-  Sends the contents of the SVG file `name` in the configured
-  directory.
-
-  Returns a safe HTML string with the contents of the SVG file
-  using the `default_collection` configuration.
-  "generic" value.
+  Returns a safe HTML string with the contents of the SVG file using the `default_collection` configuration.
 
   ## Examples
+
       <%= svg_image(@conn, "home") %>
       <%= svg_image(YourAppWeb.Endpoint, "home") %>
 
@@ -124,15 +104,10 @@ defmodule PhoenixInlineSvg.Helpers do
   end
 
   @doc """
-  Sends the contents of the SVG file `name` in the directory
-  with extra `opts` options.
-
-  Returns a safe HTML string with the contents of the SVG file
-  after apply options.
-
-  Available options: `:id, :class`
+  Returns a safe HTML string with the contents of the SVG file after inserting the given HTML attributes.
 
   ## Examples
+  
       <%= svg_image(@conn, "home", class: "logo", id: "bounce-animation") %>
       <%= svg_image(YourAppWeb.Endpoint, "home", class: "logo", id: "bounce-animation") %>
 
@@ -145,21 +120,15 @@ defmodule PhoenixInlineSvg.Helpers do
   The main function is `svg_image/4`.
 
   """
-  def svg_image(conn_or_endpoint, name, opts) when is_list(opts) do
-    svg_image(conn_or_endpoint, name, config_or_default(:default_collection, "generic"), opts)
+  def svg_image(conn_or_endpoint, name, attrs) when is_list(attrs) do
+    svg_image(conn_or_endpoint, name, config_or_default(:default_collection, "generic"), attrs)
   end
 
   @doc """
-  Sends the contents of the SVG file `name` in the `context`
-  directory with extra `opts` options.
-
-  Returns a safe HTML string with the contents of the SVG file
-  using the `default_collection` configuration.
-  `generic` value after apply options.
+  Returns a safe HTML string with the contents of the SVG file for the given collection after inserting the given HTML attributes.  
 
   ## Examples
-  Find SVG file inside of "fontawesome" folder
-
+  
       <%= svg_image(@conn, "user", "fontawesome") %>
       <%= svg_image(YourAppWeb.Endpoint, "user", "fontawesome") %>
 
@@ -168,8 +137,7 @@ defmodule PhoenixInlineSvg.Helpers do
   <svg>...</svg>
   ```
 
-  Find SVG file inside of "icons" folder and add
-  class "fa fa-share" and id "bounce-animation"
+  Find SVG file inside of "icons" folder and add class "fa fa-share" and id "bounce-animation"
 
       <%= svg_image(@conn, "user", "icons", class: "fa fa-share", id: "bounce-animation") %>
       <%= svg_image(YourAppWeb.Endpoint, "user", "icons", class: "fa fa-share", id: "bounce-animation") %>
@@ -181,35 +149,17 @@ defmodule PhoenixInlineSvg.Helpers do
 
   """
 
-  def svg_image(conn_or_endpoint, name, collection, opts \\ []) do
+  def svg_image(conn_or_endpoint, name, collection, attrs \\ []) do
     "#{collection}/#{name}.svg"
     |> read_svg_file(conn_or_endpoint)
-    |> apply_opts(opts)
-    |> safety_string
-  end
-
-  defp apply_opts(html, []), do: html
-  defp apply_opts(html, opts) do
-    Enum.reduce(opts, html, fn({opt, value}, acc) ->
-      attr =
-        opt
-        |> to_string
-        |> String.replace("_", "-")
-
-      acc
-      |> Floki.attr("svg", attr, &String.trim("#{&1} #{value}"))
-      |> Floki.raw_html
-    end)
-  end
-
-  defp safety_string(html) do
-    {:safe, html}
+    |> PhoenixInlineSvg.Utils.insert_attrs(attrs)
+    |> PhoenixInlineSvg.Utils.safety_string
   end
 
   defp read_svg_from_path(path) do
     case File.read(path) do
       {:ok, result} ->
-        result
+        String.trim(result)
       {:error, _} ->
         config_or_default(:not_found,
           "<svg viewbox='0 0 60 60'>" <>
@@ -269,17 +219,34 @@ defmodule PhoenixInlineSvg.Helpers do
     |> Enum.into([])
   end
 
-  defp create_cached_svg_image({collection, name}, svgs_path) do
-    filename = name |> String.split(".") |> List.first
+  defp create_cached_svg_image({collection, name}) do
+    filename =
+      name
+      |> String.split("/")
+      |> List.last
+      |> String.split(".") 
+      |> List.first
+    svg = read_svg_from_path(name)
 
     quote do
+      def svg_image(unquote(filename)) do
+        unquote(PhoenixInlineSvg.Utils.safety_string(svg))
+      end
+
       def svg_image(unquote(filename), unquote(collection)) do
-        unquote(
-          [svgs_path, collection, name]
-          |> Path.join
-          |> read_svg_from_path
-          |> safety_string
-        )
+        unquote(PhoenixInlineSvg.Utils.safety_string(svg))
+      end
+
+      def svg_image(unquote(filename), opts) when is_list(opts) do
+        unquote(svg)
+        |> PhoenixInlineSvg.Utils.insert_attrs(opts)
+        |> PhoenixInlineSvg.Utils.safety_string
+      end
+
+      def svg_image(unquote(filename), unquote(collection), opts) do
+        unquote(svg)
+        |> PhoenixInlineSvg.Utils.insert_attrs(opts)
+        |> PhoenixInlineSvg.Utils.safety_string
       end
     end
   end

--- a/lib/phoenix_inline_svg/utils.ex
+++ b/lib/phoenix_inline_svg/utils.ex
@@ -13,4 +13,7 @@ defmodule PhoenixInlineSvg.Utils do
   def safety_string(html) do
     {:safe, html}
   end
+
+  def insert_generic_funcs(ast, "generic"), do: ast
+  def insert_generic_funcs(_ast, _collection), do: nil
 end

--- a/lib/phoenix_inline_svg/utils.ex
+++ b/lib/phoenix_inline_svg/utils.ex
@@ -2,11 +2,12 @@ defmodule PhoenixInlineSvg.Utils do
   @moduledoc false
 
   def insert_attrs(html, []), do: html
+
   def insert_attrs(html, attrs) do
-    Enum.reduce(attrs, html, fn({attr, value}, acc) ->
+    Enum.reduce(attrs, html, fn {attr, value}, acc ->
       acc
       |> Floki.attr("svg", to_string(attr), &String.trim("#{&1} #{value}"))
-      |> Floki.raw_html
+      |> Floki.raw_html()
     end)
   end
 
@@ -14,6 +15,22 @@ defmodule PhoenixInlineSvg.Utils do
     {:safe, html}
   end
 
-  def insert_generic_funcs(ast, "generic"), do: ast
-  def insert_generic_funcs(_ast, _collection), do: nil
+  def insert_generic_funcs(ast, collection) do
+    default =
+      config_or_default(:default_collection, "generic")
+
+    if default == collection do
+      ast
+    end
+  end
+
+  def config_or_default(config, default) do
+    case Application.fetch_env(:phoenix_inline_svg, config) do
+      :error ->
+        default
+
+      {:ok, data} ->
+        data
+    end
+  end
 end

--- a/lib/phoenix_inline_svg/utils.ex
+++ b/lib/phoenix_inline_svg/utils.ex
@@ -5,8 +5,13 @@ defmodule PhoenixInlineSvg.Utils do
 
   def insert_attrs(html, attrs) do
     Enum.reduce(attrs, html, fn {attr, value}, acc ->
+      attr =
+        attr
+        |> to_string
+        |> String.replace("_", "-")
+
       acc
-      |> Floki.attr("svg", to_string(attr), &String.trim("#{&1} #{value}"))
+      |> Floki.attr("svg", attr, &String.trim("#{&1} #{value}"))
       |> Floki.raw_html()
     end)
   end
@@ -16,8 +21,7 @@ defmodule PhoenixInlineSvg.Utils do
   end
 
   def insert_generic_funcs(ast, collection) do
-    default =
-      config_or_default(:default_collection, "generic")
+    default = config_or_default(:default_collection, "generic")
 
     if default == collection do
       ast

--- a/lib/phoenix_inline_svg/utils.ex
+++ b/lib/phoenix_inline_svg/utils.ex
@@ -1,0 +1,16 @@
+defmodule PhoenixInlineSvg.Utils do
+  @moduledoc false
+
+  def insert_attrs(html, []), do: html
+  def insert_attrs(html, attrs) do
+    Enum.reduce(attrs, html, fn({attr, value}, acc) ->
+      acc
+      |> Floki.attr("svg", to_string(attr), &String.trim("#{&1} #{value}"))
+      |> Floki.raw_html
+    end)
+  end
+
+  def safety_string(html) do
+    {:safe, html}
+  end
+end

--- a/priv/static/svg/custom/custom_collection.svg
+++ b/priv/static/svg/custom/custom_collection.svg
@@ -1,0 +1,1 @@
+<svg id="custom"></svg>

--- a/priv/static/svg/custom/sub_dir/in_sub_dir.svg
+++ b/priv/static/svg/custom/sub_dir/in_sub_dir.svg
@@ -1,0 +1,1 @@
+<svg id="in-custom-collection-sub-dir"></svg>

--- a/priv/static/svg/generic/sub_dir/in_sub_dir.svg
+++ b/priv/static/svg/generic/sub_dir/in_sub_dir.svg
@@ -1,0 +1,1 @@
+<svg id="in-sub-dir"></svg>

--- a/test/phoenix_inline_svg/helpers_test.exs
+++ b/test/phoenix_inline_svg/helpers_test.exs
@@ -18,7 +18,8 @@ defmodule PhoenixInlineSvg.HelpersTest do
 
   describe "static svg_image/3" do
     test "renders an svg with an html class" do
-      actual = PhoenixInlineSvg.Helpers.svg_image(TestApp.Endpoint, "test_svg", class: "fill-current")
+      actual =
+        PhoenixInlineSvg.Helpers.svg_image(TestApp.Endpoint, "test_svg", class: "fill-current")
 
       assert actual == {:safe, ~s|<svg class="fill-current"></svg>|}
     end
@@ -30,7 +31,10 @@ defmodule PhoenixInlineSvg.HelpersTest do
     end
 
     test "renders an svg with an html class appended to an existing class" do
-      actual = PhoenixInlineSvg.Helpers.svg_image(TestApp.Endpoint, "test_with_class_svg", class: "fill-current")
+      actual =
+        PhoenixInlineSvg.Helpers.svg_image(TestApp.Endpoint, "test_with_class_svg",
+          class: "fill-current"
+        )
 
       assert actual == {:safe, ~s|<svg class="existing-class fill-current"></svg>|}
     end
@@ -42,7 +46,11 @@ defmodule PhoenixInlineSvg.HelpersTest do
     end
 
     test "renders an svg with an html class and id" do
-      actual = PhoenixInlineSvg.Helpers.svg_image(TestApp.Endpoint, "test_svg", class: "fill-current", id: "the-image")
+      actual =
+        PhoenixInlineSvg.Helpers.svg_image(TestApp.Endpoint, "test_svg",
+          class: "fill-current",
+          id: "the-image"
+        )
 
       assert actual == {:safe, ~s|<svg id="the-image" class="fill-current"></svg>|}
     end
@@ -68,6 +76,12 @@ defmodule PhoenixInlineSvg.HelpersTest do
     test "doesn't generate 1 arity functions for custom collections" do
       assert_raise FunctionClauseError, fn -> svg_image("custom_collection") end
     end
+
+    test "renders svg from subdir" do
+      actual = svg_image("sub_dir/in_sub_dir")
+
+      assert actual == {:safe, ~s|<svg id="in-sub-dir"></svg>|}
+    end
   end
 
   describe "dynamic svg_image/2" do
@@ -84,7 +98,15 @@ defmodule PhoenixInlineSvg.HelpersTest do
     end
 
     test "doesn't generate 2 arity functions for custom collections" do
-      assert_raise FunctionClauseError, fn -> svg_image("custom_collection", class: "fill-current") end
+      assert_raise FunctionClauseError, fn ->
+        svg_image("custom_collection", class: "fill-current")
+      end
+    end
+
+    test "renders an svg from subdir" do
+      actual = svg_image("sub_dir/in_sub_dir", "custom")
+
+      assert actual == {:safe, ~s|<svg id="in-custom-collection-sub-dir"></svg>|}
     end
   end
 

--- a/test/phoenix_inline_svg/helpers_test.exs
+++ b/test/phoenix_inline_svg/helpers_test.exs
@@ -64,6 +64,10 @@ defmodule PhoenixInlineSvg.HelpersTest do
 
       assert actual == {:safe, ~s|<svg></svg>|}
     end
+
+    test "doesn't generate 1 arity functions for custom collections" do
+      assert_raise FunctionClauseError, fn -> svg_image("custom_collection") end
+    end
   end
 
   describe "dynamic svg_image/2" do
@@ -77,6 +81,10 @@ defmodule PhoenixInlineSvg.HelpersTest do
       actual = svg_image("custom_collection", "custom")
 
       assert actual == {:safe, ~s|<svg id="custom"></svg>|}
+    end
+
+    test "doesn't generate 2 arity functions for custom collections" do
+      assert_raise FunctionClauseError, fn -> svg_image("custom_collection", class: "fill-current") end
     end
   end
 

--- a/test/phoenix_inline_svg/helpers_test.exs
+++ b/test/phoenix_inline_svg/helpers_test.exs
@@ -1,5 +1,6 @@
 defmodule PhoenixInlineSvg.HelpersTest do
   use ExUnit.Case, async: true
+  use PhoenixInlineSvg.Helpers, otp_app: :phoenix_inline_svg
 
   setup do
     start_supervised!(TestApp.Endpoint)
@@ -7,15 +8,15 @@ defmodule PhoenixInlineSvg.HelpersTest do
     :ok
   end
 
-  describe "svg_image/2" do
+  describe "static svg_image/2" do
     test "renders an svg" do
       actual = PhoenixInlineSvg.Helpers.svg_image(TestApp.Endpoint, "test_svg")
 
-      assert actual == {:safe, "<svg></svg>\n"}
+      assert actual == {:safe, "<svg></svg>"}
     end
   end
 
-  describe "svg_image/3" do
+  describe "static svg_image/3" do
     test "renders an svg with an html class" do
       actual = PhoenixInlineSvg.Helpers.svg_image(TestApp.Endpoint, "test_svg", class: "fill-current")
 
@@ -54,6 +55,36 @@ defmodule PhoenixInlineSvg.HelpersTest do
       actual = PhoenixInlineSvg.Helpers.svg_image(TestApp.Endpoint, "test_svg", opts)
 
       assert actual == {:safe, ~s|<svg #{attr}="value"></svg>|}
+    end
+  end
+
+  describe "dynamic svg_image/1" do
+    test "renders an svg from a generated function" do
+      actual = svg_image("test_svg")
+
+      assert actual == {:safe, ~s|<svg></svg>|}
+    end
+  end
+
+  describe "dynamic svg_image/2" do
+    test "renders an svg from a generated function that takes a list of attributes" do
+      actual = svg_image("test_svg", class: "fill-current")
+
+      assert actual == {:safe, ~s|<svg class="fill-current"></svg>|}
+    end
+
+    test "renders an svg from a generated function that is from a different collection" do
+      actual = svg_image("custom_collection", "custom")
+
+      assert actual == {:safe, ~s|<svg id="custom"></svg>|}
+    end
+  end
+
+  describe "dynamic svg_image/3" do
+    test "renders an svg from a generated function that is from a different collection and has opts" do
+      actual = svg_image("custom_collection", "custom", class: "fill-current")
+
+      assert actual == {:safe, ~s|<svg class="fill-current" id="custom"></svg>|}
     end
   end
 end


### PR DESCRIPTION
This will precompile the user's images into functions that let them use images from the default collection, custom collections, and insert dynamic HTML attributes.

This also cleans up the documentation and changes the tone to imply that the precompiled functions are the default way to use this library, instead of the "new" way.

Eventually the "old" way should be deprecated and removed from the library.

Addresses #9 

@nikkomiu I would review and merge #13 before reviewing this. I forgot to use a branch for that PR, so until that one is merged, this PR will show both sets of changes. This PR is also dependent on changes from PR #13