### PR TITLE
Handle multi word html attributes

### DIFF
--- a/lib/phoenix_inline_svg/helpers.ex
+++ b/lib/phoenix_inline_svg/helpers.ex
@@ -191,8 +191,13 @@ defmodule PhoenixInlineSvg.Helpers do
   defp apply_opts(html, []), do: html
   defp apply_opts(html, opts) do
     Enum.reduce(opts, html, fn({opt, value}, acc) ->
+      attr =
+        opt
+        |> to_string
+        |> String.replace("_", "-")
+
       acc
-      |> Floki.attr("svg", to_string(opt), &String.trim("#{&1} #{value}"))
+      |> Floki.attr("svg", attr, &String.trim("#{&1} #{value}"))
       |> Floki.raw_html
     end)
   end

--- a/test/phoenix_inline_svg/helpers_test.exs
+++ b/test/phoenix_inline_svg/helpers_test.exs
@@ -22,6 +22,12 @@ defmodule PhoenixInlineSvg.HelpersTest do
       assert actual == {:safe, ~s|<svg class="fill-current"></svg>|}
     end
 
+    test "converts multi word attrs from snake case to kebab case" do
+      actual = PhoenixInlineSvg.Helpers.svg_image(TestApp.Endpoint, "test_svg", aria_labelledby: "me")
+
+      assert actual == {:safe, ~s|<svg aria-labelledby="me"></svg>|}
+    end
+
     test "renders an svg with an html class appended to an existing class" do
       actual = PhoenixInlineSvg.Helpers.svg_image(TestApp.Endpoint, "test_with_class_svg", class: "fill-current")
 


### PR DESCRIPTION
This is necessary since keyword list keys cannot contain dashes

Addresses #12 