### PR TITLE
Allow precompiling of SVGs only once

### DIFF
--- a/lib/phoenix_inline_svg/helpers.ex
+++ b/lib/phoenix_inline_svg/helpers.ex
@@ -70,17 +70,50 @@ defmodule PhoenixInlineSvg.Helpers do
 
   """
   defmacro __using__([otp_app: app_name] = _opts) do
-    svgs_path = Application.app_dir(app_name,
-      PhoenixInlineSvg.Utils.config_or_default(:dir, "priv/static/svg/"))
+    precompile(app_name)
+  end
+
+  defmacro __using__(_) do
+    raise "You must specifiy an OTP app!"
+  end
+
+  @doc """
+  Precompile the SVG images into functions once, as opposed to `__using__` macro.
+  
+  To use this, import Helpers into your views function:
+
+      def view do
+        quote do
+          import PhoenixInlineSvg.Helpers
+        end
+      end
+      
+  Afterwards, add a call to `precompile` function in `start` function of your `application.ex` file:
+
+        def start(_type, _args) do
+          children = [
+            ...
+          ]
+        
+          # precompile svgs to functions
+          PhoenixInlineSvg.Helpers.precompile(:persense)
+        
+          opts = [strategy: :one_for_one, name: Persense.Supervisor]
+          Supervisor.start_link(children, opts)
+        end
+
+  """
+  def precompile(app_name) do
+    svgs_path =
+      Application.app_dir(
+        app_name,
+        PhoenixInlineSvg.Utils.config_or_default(:dir, "priv/static/svg/")
+      )
 
     svgs_path
     |> find_collection_sets
     |> Enum.uniq
     |> Enum.map(&create_cached_svg_image(&1))
-  end
-
-  defmacro __using__(_) do
-    raise "You must specifiy an OTP app!"
   end
 
   @doc """


### PR DESCRIPTION
Hello,

I am very new to Elixir world, so please take this PR as being submmited by a newbie.

I just imported a theme from ThemeForest into my app, wherein I added this library. However, the theme generated somewhere around ~1200+ svgs, which I wanted to keep for future reference.

However, this led to huge compilation times - primarily, since using `use PhoenixInlineSvg` inside the `views` function was triggering precompiling of SVGs for each view (as far as I understand this).

Therefore, I extracted the function into a separate call away from `__using__` macro, which can be used in its own to only precompile SVGs once. Effectively, I am now able to compile my app, correctly.

I am really not sure if this is the correct way to run something once in Phoenix. If not, please advise.

Regards,