### PR TITLE
Fix view helper usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ end
 ### Generic Collection
 
 ```elixir
-<%= PhoenixInlineSvg.Helpers.svg_image(@conn, "home") %>
+<%= svg_image(@conn, "home") %>
 ```
 
 Where `home` is the name of the SVG file you want to load.
@@ -61,7 +61,7 @@ NOTE: Make sure your svg's are stored in `/assets/static/svg/generic/` or your a
 There is an optional argument in the function to allow for breaking up SVG files into collections (or folders on the filesystem):
 
 ```
-<%= PhoenixInlineSvg.Helpers.svg_image(@conn, "user", "fontawesome") %>
+<%= svg_image(@conn, "user", "fontawesome") %>
 ```
 
 Will result in the output:
@@ -82,7 +82,7 @@ You can also pass optional HTML attributes into the function to set
 those properties on the SVG.
 
 ```
-<%= PhoenixInlineSvg.Helpers.svg_image(@conn,"home", class: "logo", id: "bounce-animation") %>
+<%= svg_image(@conn,"home", class: "logo", id: "bounce-animation") %>
 ```
 
 Will result in the output:


### PR DESCRIPTION
Using the module name in the helper doesn't work due to the way the macro is applied.